### PR TITLE
fix: sample code in render.md

### DIFF
--- a/markdown/render.md
+++ b/markdown/render.md
@@ -76,14 +76,14 @@ function vertical.main()
       -- Draw the rest of the items
       for i = 1, results_limit do
 
-         -- We are back at the beginning
-         if index == variables.selected then
-            goto redraw
-         end
-
          -- Wrap around at the end
          if index > results_limit then
             index = 1
+         end
+
+         -- We are back at the beginning
+         if index == variables.selected then
+            goto redraw
          end
 
          -- No point in rendering that which cannot be rendered


### PR DESCRIPTION
The sample code did not seem to be working correctly, so we fixed it.
If this is a mistake, I would appreciate it if you could let me know.

Before:
![before](https://user-images.githubusercontent.com/16581287/114292975-68abe100-9acd-11eb-8bb6-5557741bd9d1.gif)

After:
![After](https://user-images.githubusercontent.com/16581287/114292983-706b8580-9acd-11eb-8a35-1b3fb7202f8f.gif)
